### PR TITLE
Secure workflow by updating GitHub token and Docker step

### DIFF
--- a/.github/workflows/build_n_deploy.yml
+++ b/.github/workflows/build_n_deploy.yml
@@ -2,9 +2,6 @@ name: build & deploy service
 
 on:
   workflow_call:
-     secrets:
-        GH_TOKEN:
-          required: true
   push:
     branches: [ master ]
 
@@ -29,16 +26,14 @@ jobs:
       - name: Build ui
         run: mvn -B --no-transfer-progress clean package -DskipTests
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
-          USER_NAME: fo0
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: mr-smithers-excellent/docker-build-push@v5
-        name: Build & push Docker image
+      - name: Build & push Docker image
+        uses: docker/build-push-action@v2
         with:
-          image: geolocation-service
-          tags: ${{steps.date.outputs.date}}, latest
-          registry: ghcr.io
-          dockerfile: Dockerfile
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/fo0/geolocation-service:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_n_deploy.yml
+++ b/.github/workflows/build_n_deploy.yml
@@ -34,6 +34,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/fo0/geolocation-service:latest
+          tags: ghcr.io/fo0/geolocation-service:latest, ghcr.io/fo0/geolocation-service:${{ steps.date.outputs.date }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove the `GH_TOKEN` secret from the `workflow_call` section.

Add the `GITHUB_TOKEN` secret in the `env` section of the `Build ui` step.

Add a new step to build and push the Docker image using `docker/build-push-action@v2`.

